### PR TITLE
FRDM-MCXN947でVTORに使用するknl_exctblのアライメント修正

### DIFF
--- a/sysdepend/nxp_mcux/cpu/core/armv8m/sys_start.c
+++ b/sysdepend/nxp_mcux/cpu/core/armv8m/sys_start.c
@@ -26,7 +26,7 @@
 
 /* Exception handler table (RAM) */
 EXPORT UW knl_exctbl[sizeof(UW)*(N_SYSVEC + N_INTVEC)]
-	__attribute__((section(".mtk_exctbl"))) __attribute__ ((aligned(256)));
+	__attribute__((section(".mtk_exctbl"))) __attribute__ ((aligned(1024)));
 
 EXPORT UW *knl_exctbl_o;	// Exception handler table (Origin)
 


### PR DESCRIPTION
## 問題点
FRDM-MCXN947を使用する構成において、割込み要因と実行される割込みが異なる場合があります。
例えば、割込みベクタ93番(EDMA_1_CH0_IRQHandler)が実行されるべき場面で、割込みベクタ29番(EDMA_0_CH12_IRQHandler)が実行されます。

## 問題の原因
mtk3_bsp2では、RAM上の割込みベクタテーブルを使用するために`sysdepend/nxp_mcux/cpu/core/armv8m/sys_start.c`の`knl_start_mtkernel`関数で、VTOR(Vector Table Offset Register)に`knl_exctbl`のアドレスをセットしています。
knl_exectblは以下のように256byteでアライメントが指定されています。
```c
/* Exception handler table (RAM) */
EXPORT UW knl_exctbl[sizeof(UW)*(N_SYSVEC + N_INTVEC)]
        __attribute__((section(".mtk_exctbl"))) __attribute__ ((aligned(256)));
```

ARMv8-Mのリファレンスマニュアル(https://developer.arm.com/documentation/ddi0553/latest/) によると、VTORには以下の制約があります。
> In a PE with a configurable vector table base, the vector table is naturally-aligned to a power of two, with an
> alignment value that is:
> • A minimum of 128 bytes.
> • Greater than or equal to (Number of Exceptions supported x4).

FRDM-MCXN947では、割込みベクタのエントリ数は172です。上記の制約に従うと、アライメントは172×4 = 688byte以上(つまり1024byte以上)を指定する必要があります。

## 提案する修正の内容
割込みベクタテーブルを格納する配列`knl_exctbl`のアライメントを1024バイトに変更します。
FRDM-MXCN947以外のボードでも同様の問題が発生する可能性がありますが、手元に他のボードが無く検証できないためFRDM-MXCN947に関するコードのみ修正します。

## 補足
Arm v8-mにおける割込みベクタのアドレス計算は、内部的にVTOR と割込みベクタ番号に対応するオフセット量 (=ベクタ番号×4)のビット論理和(OR)で計算されるようです。
例えばVTORに0x20000100のような256byte境界のアドレスが設定されると以下のように動作します。（実際に[mtk3bsp2_sample](https://github.com/tron-forum/mtk3bsp2_samples)ではVTORに0x20000100がセットされます）

|ベクタ番号|オフセット量|期待するベクタアドレスの計算結果|実際のベクタアドレスの計算結果|
|:-|:-|:-|:-|
|93|0x174(=93×4)|0x20000274 ( = 0x02000100 + 0x174)|0x20000174 ( = 0x02000100 \| 0x174)|
|29|0x074(=29×4)|0x20000174 ( = 0x02000100 + 0x074)|0x20000174 ( = 0x02000100 \| 0x074)|

このため、VTORが0x20000100の場合、ベクタ93番で0x20000274のハンドラ実行が期待されるときに、0x20000174( =ベクタ29番)のハンドラが実行されてしまいます。

VTORに1024byte境界(例えば0x20000400)のアドレスがセットされる場合、上記の問題は発生しません。
|ベクタ番号|オフセット量|期待するベクタアドレスの計算結果|実際のベクタアドレスの計算結果|
|:-|:-|:-|:-|
|93|0x174(=93×4)|0x20000574 ( = 0x02000400 + 0x174)|0x20000574 ( = 0x02000400 \| 0x174)|
|29|0x074(=29×4)|0x20000474 ( = 0x02000400 + 0x074)|0x20000474 ( = 0x02000400 \| 0x074)|
